### PR TITLE
Add signet to bech32 currency codes

### DIFF
--- a/bolt11/conf/bech32_currency_codes.json
+++ b/bolt11/conf/bech32_currency_codes.json
@@ -3,5 +3,6 @@
   "bcrt": "regtest",
   "ltc": "litecoin",
   "tb": "testnet",
+  "tbs": "signet",
   "sb": "simnet"
 }


### PR DESCRIPTION
Looking to get `lightning` NPM package working with custom signet, it was failing due to the currency code not parsing in this package. 

This fixes an invalid  `UnknownCurrencyCodeInPaymentRequest` exception when decoding a `signet` network payment request. This exception was trapped in `lightning` library and emitted a `ExpectedValidPaymentRequestForInvoice` when calling `createInvoice` function under 'signet'